### PR TITLE
Rename variable used for M5 remote address

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ MAC in Serial Looks like: 34:86:5D:57:F5:84
 
 Change to this:
 
-"#define OSSM 1"
-"uint8_t OSSM_Address[] = {0x34, 0x86, 0x5d, 0x57, 0xf5, 0x84};"
+"uint8_t Remote_Address[] = {0x34, 0x86, 0x5d, 0x57, 0xf5, 0x84};"
 
 # Display Menü 
 

--- a/src/OSSM_Config.h
+++ b/src/OSSM_Config.h
@@ -3,6 +3,12 @@
 */
 
 /*
+        Remote config
+*/
+
+uint8_t Remote_Address[] = {0x08, 0x3A, 0xF2, 0x68, 0x1E, 0x74};
+
+/*
         Motion System Config
 */
 
@@ -31,7 +37,3 @@
 // The minimum value of the pot in percent
 // prevents noisy pots registering commands when turned down to zero by user
 const float commandDeadzonePercentage = 1.0f;
-
-//OSSM M5 Remote MAC
-
-uint8_t broadcastAddress[] = {0x08, 0x3A, 0xF2, 0x68, 0x1E, 0x74};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,7 +231,7 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
     outgoingcontrol.esp_speed = USER_SPEEDLIMIT;
     outgoingcontrol.esp_depth = MAX_STROKEINMM;
     outgoingcontrol.esp_pattern = Stroker.getPattern();
-    esp_err_t result = esp_now_send(broadcastAddress, (uint8_t *) &outgoingcontrol, sizeof(outgoingcontrol));
+    esp_err_t result = esp_now_send(Remote_Address, (uint8_t *) &outgoingcontrol, sizeof(outgoingcontrol));
     if (result == ESP_OK) {
       esp_connect = true;
     }
@@ -242,7 +242,7 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
     outgoingcontrol.esp_speed = USER_SPEEDLIMIT;
     outgoingcontrol.esp_depth = MAX_STROKEINMM;
     outgoingcontrol.esp_pattern = Stroker.getPattern();
-    esp_err_t result = esp_now_send(broadcastAddress, (uint8_t *) &outgoingcontrol, sizeof(outgoingcontrol));
+    esp_err_t result = esp_now_send(Remote_Address, (uint8_t *) &outgoingcontrol, sizeof(outgoingcontrol));
     if (result == ESP_OK) {
       esp_connect = true;
     }
@@ -756,7 +756,7 @@ void espNowRemoteTask(void *pvParameters)
     esp_now_register_send_cb(OnDataSent);
 
     // Register peer
-    memcpy(peerInfo.peer_addr, broadcastAddress, 6);
+    memcpy(peerInfo.peer_addr, Remote_Address, 6);
     peerInfo.channel = 0;  
     peerInfo.encrypt = false;
   


### PR DESCRIPTION
I updated the README so that it mentions the correct name of the remote MAC address variable. I also changed the name of the variable to make it more clear what the value should be.