### PR TITLE
Implement sensorless homing

### DIFF
--- a/lib/StrokeEngine/src/StrokeEngine.h
+++ b/lib/StrokeEngine/src/StrokeEngine.h
@@ -68,6 +68,11 @@ typedef struct {
   uint8_t pinMode;            /*> Pinmode of the switch INPUT, INPUT_PULLUP, INPUT_PULLDOWN */
 } endstopProperties;
 
+typedef struct {
+  int currentPin; /*> Pin connected to current sensor */
+  float currentLimit; /*> Current limit */
+} sensorlessHomeProperties;
+
 /**************************************************************************/
 /*!
   @brief  Enum containing the states of the state machine
@@ -246,6 +251,9 @@ class StrokeEngine {
         void enableAndHome(endstopProperties *endstop, float speed = 5.0);
         void enableAndHome(endstopProperties *endstop, void(*callBackHoming)(bool), float speed = 5.0);
 
+        void enableAndSensorlessHome(sensorlessHomeProperties *sensorless, float speed = 5.0);
+        void enableAndSensorlessHome(sensorlessHomeProperties *sensorless, void(*callBackHoming)(bool), float speed = 5.0);
+
         /**************************************************************************/
         /*!
           @brief  If no homing switch is present homing can be done manually. Push 
@@ -401,8 +409,11 @@ class StrokeEngine {
         float _timeOfStroke;
         float _sensation;
         bool _applyUpdate = false;
+        bool _abortHoming = false;
         static void _homingProcedureImpl(void* _this) { static_cast<StrokeEngine*>(_this)->_homingProcedure(); }
         void _homingProcedure();
+        void _sensorHomingProcedure();
+        void _sensorlessHomingProcedure();
         static void _strokingImpl(void* _this) { static_cast<StrokeEngine*>(_this)->_stroking(); }
         void _stroking();
         static void _streamingImpl(void* _this) { static_cast<StrokeEngine*>(_this)->_streaming(); }
@@ -414,10 +425,14 @@ class StrokeEngine {
         void _applyMotionProfile(motionParameter* motion);
         void(*_callBackHomeing)(bool) = NULL;
         void(*_callbackTelemetry)(float, float, bool) = NULL;
+        bool _sensorlessHomeing;
         int _homeingSpeed;
         int _homeingPin;
+        int _sensorlessHomeingCurrentPin;
+        float _sensorlessHomeingCurrentLimit;
         int _homeingToBack;
         bool _homeingActiveLow;      /*> Polarity of the homing signal*/
         bool _fancyAdjustment;
         void _setupDepths();
+        float _getAnalogAveragePercent(int pinNumber, int samples);
 };

--- a/src/OSSM_Config.h
+++ b/src/OSSM_Config.h
@@ -9,6 +9,8 @@ uint8_t Broadcast_Address[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 uint8_t Remote_Address[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 //uint8_t Remote_Address[] = {0x08, 0x3A, 0xF2, 0x68, 0x1E, 0x74};
 
+#define EEPROM_SIZE 200
+
 #define OSSM_ID  1 //OSSM_ID Default can be changed with M5 Remote in the Future will be Saved in EPROOM
 #define M5_ID 99 //M5_ID Default can be changed with M5 Remote in the Future will be Saved in EPROOM
 


### PR DESCRIPTION
This pull request implements sensorless homing when the hardwareVersion writen to the EEPROM is >= 20, similarly to the stock OSSM firmware.

The sensorless homing itself is implemented within StrokeEngine, and this change is not yet upstreamed. I will also open a pull request for StrokeEngine to hopefully upstream this.

One behavioral change is that the esp_connected packet is now sent *after* homing is complete, because it contains the length of the rail which is discovered during sensorless homing.