### PR TITLE
OTA update support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+.src/arduino_secrets.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,20 +12,31 @@
 platform = espressif32@3.5.0
 board = esp32dev
 framework = arduino
-
 monitor_speed = 115200
-;board_build.partitions = no_ota.csv
-;upload_port = com8
-;monitor_port = com8
-;debug_tool = esp-prog
-;debug_init_break = tbreak setup
-;debug_speed = 1000
 lib_deps = 
-        gin66/FastAccelStepper @ ^0.23.2
-        adafruit/Adafruit BusIO @ ^1.5.0
-        adafruit/Adafruit GFX Library @ ^1.10.1
-        adafruit/Adafruit SSD1306 @ ^2.4.0
-        jchristensen/JC_Button @ ^2.1.2
-        mathertel/OneButton@^2.0.3
-        ModbusClient=https://github.com/eModbus/eModbus.git#v1.5-stable
-        AsyncTCP=https://github.com/me-no-dev/AsyncTCP.git
+	gin66/FastAccelStepper @ ^0.23.2
+	adafruit/Adafruit BusIO @ ^1.5.0
+	adafruit/Adafruit GFX Library @ ^1.10.1
+	adafruit/Adafruit SSD1306 @ ^2.4.0
+	jchristensen/JC_Button @ ^2.1.2
+	mathertel/OneButton@^2.0.3
+	ModbusClient=https://github.com/eModbus/eModbus.git#v1.5-stable
+
+
+
+[env:esp32dev-ota]
+platform = espressif32@3.5.0
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+upload_protocol = espota
+upload_port = 0.0.0.0 ; Enter your ESP32 IP address here
+lib_deps = 
+	gin66/FastAccelStepper @ ^0.23.2
+	adafruit/Adafruit BusIO @ ^1.5.0
+	adafruit/Adafruit GFX Library @ ^1.10.1
+	adafruit/Adafruit SSD1306 @ ^2.4.0
+	jchristensen/JC_Button @ ^2.1.2
+	mathertel/OneButton@^2.0.3
+	ModbusClient=https://github.com/eModbus/eModbus.git#v1.5-stable
+

--- a/src/arduino_secrets.h
+++ b/src/arduino_secrets.h
@@ -1,0 +1,8 @@
+#ifndef ARDUIO_SECRETS_H
+#define ARDUIO_SECRETS_H
+
+#define SSID "SSID" // SSID of your WiFi
+#define PASS "PASSWORD" // Password of your WiFi
+
+#endif // ARDUIO_SECRETS_H
+```

--- a/src/arduino_secrets.h
+++ b/src/arduino_secrets.h
@@ -2,7 +2,6 @@
 #define ARDUIO_SECRETS_H
 
 #define SSID "SSID" // SSID of your WiFi
-#define PASS "PASSWORD" // Password of your WiFi
+#define PASSWORD "PASSWORD" // Password of your WiFi
 
 #endif // ARDUIO_SECRETS_H
-```


### PR DESCRIPTION
To enable OTA support for uploading via WiFi from PIO, follow these steps:

1- Uncomment the line "#define OTA_UPDATE" in your code.
2- Open the "arduino_secrets.h" file and add your SSID and PASSWORD.
3- Modify the "platformio.ini" file and add your ESP32's IP address.

Since alternating between ESP now protocol and wifi cause issue, I add a command that reset the ESP32 to enable the OTA on your OSSM. The command cause the esp32 to make a deepsleep reset and upon reset it check the reset reason and enable OTA and wait for an update. 

A function needs to be implemented in the m5-remote repository to send the command "15" to enable OTA on your OSSM device. This command will cause the ESP32 to perform a deep sleep reset. Upon reset, it will check the reset reason, enable OTA, and wait for an update.

If no update is performed, you will need to power cycle the device to exit this state. Otherwise, at the end of the update, the device will reset and function normally.